### PR TITLE
Fix/event handler deadlock

### DIFF
--- a/lifec/src/engine/cleanup.rs
+++ b/lifec/src/engine/cleanup.rs
@@ -11,39 +11,30 @@ pub struct Cleanup;
 impl<'a> System<'a> for Cleanup {
     type SystemData = (Entities<'a>, State<'a>);
 
-    fn run(&mut self, (entities, events): Self::SystemData) {
+    fn run(&mut self, (entities, mut events): Self::SystemData) {
+        let mut to_delete = vec![];
+        let mut to_cleanup_connection = vec![];
+
         for (spawned, _, owner) in events.iter_spawned_events() {
             match events.status(*spawned) {
                 EventStatus::Completed(_) | EventStatus::Cancelled(_)
                     if entities.is_alive(*spawned) =>
                 {
-                    match events.plugins().features().broker().try_send_node_command(
-                        NodeCommand::custom("delete_spawned", *spawned),
-                        None,
-                    ) {
-                        Ok(_) => {
-                            event!(Level::DEBUG, "Deleting spawned, {}", spawned.id());
-                        }
-                        Err(err) => {
-                            event!(Level::ERROR, "Could not send node command, {err}");
-                        }
-                    }
+                    to_delete.push(*spawned);
                 }
                 EventStatus::Disposed(_) if entities.is_alive(*owner) => {
-                    match events.plugins().features().broker().try_send_node_command(
-                        NodeCommand::custom("cleanup_connection", *owner),
-                        None,
-                    ) {
-                        Ok(_) => {
-                            event!(Level::DEBUG, "Deleting spawned, {}", spawned.id());
-                        }
-                        Err(err) => {
-                            event!(Level::ERROR, "Could not send node command, {err}");
-                        }
-                    }
+                    to_cleanup_connection.push(*owner);
                 }
                 _ => {}
             }
+        }
+
+        for t in to_delete {
+            events.delete(t);
+        }
+
+        for t in to_cleanup_connection {
+            events.cleanup_connection(t);
         }
     }
 }

--- a/lifec/src/engine/connection.rs
+++ b/lifec/src/engine/connection.rs
@@ -175,7 +175,7 @@ impl Connection {
             Some(ConnectionState::duplicate(incoming, *source))
         } else {
             event!(
-                Level::WARN,
+                Level::DEBUG,
                 "Trying to schedule an unknown event, {}",
                 incoming.id()
             );

--- a/lifec/src/host/handler.rs
+++ b/lifec/src/host/handler.rs
@@ -18,7 +18,7 @@ impl ListenerSetup {
             builder.add(
                 EventHandler::new(L::create(world)),
                 "listener",
-                &["event_runtime", "cleanup"],
+                &[],
             );
         })
     }

--- a/lifec/src/plugins/events/event_runtime.rs
+++ b/lifec/src/plugins/events/event_runtime.rs
@@ -99,7 +99,7 @@ impl SetupHandler<sync::mpsc::Receiver<Completion>> for EventRuntime {
 impl SetupHandler<sync::mpsc::Sender<(NodeCommand, Option<Yielding>)>> for EventRuntime {
     fn setup(world: &mut specs::World) {
         if !world.has_value::<sync::mpsc::Sender<(NodeCommand, Option<Yielding>)>>() {
-            let (tx, rx) = mpsc::channel::<(NodeCommand, Option<Yielding>)>(10000);
+            let (tx, rx) = mpsc::channel::<(NodeCommand, Option<Yielding>)>(20000);
             world.insert(tx);
             world.insert(rx);
         }
@@ -110,7 +110,7 @@ impl SetupHandler<sync::mpsc::Sender<(NodeCommand, Option<Yielding>)>> for Event
 impl SetupHandler<sync::mpsc::Receiver<(NodeCommand, Option<Yielding>)>> for EventRuntime {
     fn setup(world: &mut specs::World) {
         if !world.has_value::<sync::mpsc::Receiver<(NodeCommand, Option<Yielding>)>>() {
-            let (tx, rx) = mpsc::channel::<(NodeCommand, Option<Yielding>)>(10000);
+            let (tx, rx) = mpsc::channel::<(NodeCommand, Option<Yielding>)>(20000);
             world.insert(tx);
             world.insert(rx);
         }


### PR DESCRIPTION
Fixes a deadlock that can occur when the cleanup system over-saturates the node command queue. 